### PR TITLE
timearry data corrected for SINGLE precision

### DIFF
--- a/fieldlib.py
+++ b/fieldlib.py
@@ -76,9 +76,15 @@ class fieldfile(object):
     # defines the struct for a time entry in field
     def TimeEntry(self):
         if self.bigendian:
-            timeentry = struct.Struct('>idi')
+            if self.pars['PRECISION'] == 'SINGLE':
+                timeentry = struct.Struct('>ifi')
+            else:
+                timeentry = struct.Struct('>idi')
         else:
-            timeentry = struct.Struct('=idi')
+            if self.pars['PRECISION'] == 'SINGLE':
+                timeentry = struct.Struct('=ifi')
+            else:
+                timeentry = struct.Struct('=idi')
         return timeentry, timeentry.size
 
     # calculate offset in field file for a given timestep and variable

--- a/momlib.py
+++ b/momlib.py
@@ -75,9 +75,15 @@ class momfile():
 #defines the struct for a time entry in field
         def TimeEntry(self):
                 if self.bigendian:
-                        timeentry=struct.Struct('>idi')
+                    if self.pars['PRECISION'] == 'SINGLE':
+                            timeentry = struct.Struct('>ifi')
+                    else:
+                            timeentry = struct.Struct('>idi')
                 else:
-                        timeentry=struct.Struct('=idi')
+                    if self.pars['PRECISION'] == 'SINGLE':
+                            timeentry = struct.Struct('=ifi')
+                    else:
+                            timeentry = struct.Struct('=idi')
                 return timeentry,timeentry.size
 
 


### PR DESCRIPTION
Time array values were hard-coded to double precision, causing errors when reading data from single-precision outputs of GENE.
A switch now ensure the correct datatype is used for either precision.
